### PR TITLE
basic assemblyscript demo

### DIFF
--- a/examples/assemblyscript/package.json
+++ b/examples/assemblyscript/package.json
@@ -5,8 +5,8 @@
   "main": "src/main.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "asc --target release -Osize",
-    "build:debug": "asc --target debug"
+    "build": "asc --exportRuntime --target release -Osize",
+    "build:debug": "asc --exportRuntime --target debug"
   },
   "author": "",
   "license": "MIT",

--- a/examples/assemblyscript/src/main.ts
+++ b/examples/assemblyscript/src/main.ts
@@ -13,7 +13,7 @@ import {
 
 export function Init() : void {
     InitWindow(800, 450, "raylib-wasm")
-    SetTargetFPS(60)
+    // SetTargetFPS(60)
 }
 
 export function UpdateDrawFrame() : void {

--- a/examples/assemblyscript/src/main.ts
+++ b/examples/assemblyscript/src/main.ts
@@ -13,11 +13,10 @@ import {
 
 export function Init() : void {
     InitWindow(800, 450, "raylib-wasm")
-    // SetTargetFPS(60)
+    SetTargetFPS(60)
 }
 
 export function UpdateDrawFrame() : void {
-    TraceLog(LOG_INFO, "UPDATE")
     BeginDrawing()
         ClearBackground(RAYWHITE)
         DrawText("Congrats! You created your first raylib-wasm C window!", 140, 200, 20, LIGHTGRAY)

--- a/examples/assemblyscript/src/main.ts
+++ b/examples/assemblyscript/src/main.ts
@@ -1,13 +1,29 @@
-import * as r from "./raylib-wasm"
+import {
+    TraceLog,
+    InitWindow,
+    SetTargetFPS,
+    BeginDrawing,
+    ClearBackground,
+    DrawText,
+    EndDrawing,
+    LOG_INFO,
+    RAYWHITE,
+    LIGHTGRAY
+} from "./raylib-wasm"
 
 export function Init() : void {
-    r.TraceLog(r.LOG_INFO, "Hello World!")
+    InitWindow(800, 450, "raylib-wasm")
+    SetTargetFPS(60)
 }
 
 export function UpdateDrawFrame() : void {
-    r.TraceLog(r.LOG_INFO, "Update Draw")
+    TraceLog(LOG_INFO, "UPDATE")
+    BeginDrawing()
+        ClearBackground(RAYWHITE)
+        DrawText("Congrats! You created your first raylib-wasm C window!", 140, 200, 20, LIGHTGRAY)
+    EndDrawing()
 }
 
 export function Close() : void {
-    r.TraceLog(r.LOG_INFO, "BYE!")
+    TraceLog(LOG_INFO, "BYE!")
 }

--- a/examples/assemblyscript/src/main.ts
+++ b/examples/assemblyscript/src/main.ts
@@ -19,7 +19,7 @@ export function Init() : void {
 export function UpdateDrawFrame() : void {
     BeginDrawing()
         ClearBackground(RAYWHITE)
-        DrawText("Congrats! You created your first raylib-wasm C window!", 140, 200, 20, LIGHTGRAY)
+        DrawText("Congrats! You created your first raylib-wasm assemblyscript window!", 140, 200, 20, LIGHTGRAY)
     EndDrawing()
 }
 

--- a/examples/assemblyscript/src/main.ts
+++ b/examples/assemblyscript/src/main.ts
@@ -19,7 +19,7 @@ export function Init() : void {
 export function UpdateDrawFrame() : void {
     BeginDrawing()
         ClearBackground(RAYWHITE)
-        DrawText("Congrats! You created your first raylib-wasm assemblyscript window!", 140, 200, 20, LIGHTGRAY)
+        DrawText("Congrats! You created your first raylib-wasm assemblyscript window!", 50, 200, 20, LIGHTGRAY)
     EndDrawing()
 }
 

--- a/examples/assemblyscript/src/raylib-wasm.ts
+++ b/examples/assemblyscript/src/raylib-wasm.ts
@@ -111,11 +111,42 @@ export const LOG_ERROR = 5
 export const LOG_FATAL = 6
 export const LOG_NONE = 7
 
-// since it takes a string arg, we convert to a UTF8 null-terminated buffer first
-@external("env", "TraceLog")
-declare function raylibTraceLog(logLevel: i32, text: ArrayBuffer) :void
-
-export function TraceLog(logLevel: i32, text: string) :void {
-    raylibTraceLog(logLevel, String.UTF8.encode(text, true))
+// convert a Color to an i32 (to pass over wasm)
+function toColor(color: Color): i32 {
+    return ((color.r & 0xFF) << 24) + ((color.g & 0xFF) << 16) + ((color.b) << 8) + (color.a & 0xFF)
 }
 
+@external("env", "SetTargetFPS")
+export declare function SetTargetFPS(fps: i32) :void
+
+@external("env", "BeginDrawing")
+export declare function BeginDrawing() :void
+
+@external("env", "EndDrawing")
+export declare function EndDrawing() :void
+
+// these need to be wrapped to convert strings & Colors 
+
+@external("env", "TraceLog")
+declare function _TraceLog(logLevel: i32, text: ArrayBuffer) :void
+export function TraceLog(logLevel: i32, text: string) :void {
+    _TraceLog(logLevel, String.UTF8.encode(text, true))
+}
+
+@external("env", "InitWindow")
+declare function _InitWindow(width: i32, height: i32, text: ArrayBuffer) :void
+export function InitWindow(width: i32, height:i32, title: string) :void {
+    _InitWindow(width, height, String.UTF8.encode(title, true))
+}
+
+@external("env", "ClearBackground")
+declare function _ClearBackground(color: i32) :void
+export function ClearBackground(color: Color): void {
+    _ClearBackground(toColor(color))
+}
+
+@external("env", "DrawText")
+declare function _DrawText(text: ArrayBuffer, x: i32, y: i32, fontSize: i32, color: i32) :void
+export function DrawText(text: string, x: i32, y: i32, fontSize: i32, color: Color) :void {
+    _DrawText(String.UTF8.encode(text, true), x, y, fontSize, toColor(color))
+}

--- a/examples/assemblyscript/src/raylib-wasm.ts
+++ b/examples/assemblyscript/src/raylib-wasm.ts
@@ -111,11 +111,6 @@ export const LOG_ERROR = 5
 export const LOG_FATAL = 6
 export const LOG_NONE = 7
 
-// convert a Color to an i32 (to pass over wasm)
-function toColor(color: Color): i32 {
-    return ((color.r & 0xFF) << 24) + ((color.g & 0xFF) << 16) + ((color.b) << 8) + (color.a & 0xFF)
-}
-
 @external("env", "SetTargetFPS")
 export declare function SetTargetFPS(fps: i32) :void
 
@@ -139,14 +134,22 @@ export function InitWindow(width: i32, height:i32, title: string) :void {
     _InitWindow(width, height, String.UTF8.encode(title, true))
 }
 
-@external("env", "ClearBackground")
-declare function _ClearBackground(color: i32) :void
-export function ClearBackground(color: Color): void {
-    _ClearBackground(toColor(color))
+// these have colors spread, but this isn't really needed (since color struct fits inside an int32)
+// here is an example util:
+
+// convert a Color to an i32 (to pass over wasm)
+function toColor(color: Color): i32 {
+    return ((color.r & 0xFF) << 24) + ((color.g & 0xFF) << 16) + ((color.b) << 8) + (color.a & 0xFF)
 }
 
-@external("env", "DrawText")
-declare function _DrawText(text: ArrayBuffer, x: i32, y: i32, fontSize: i32, color: i32) :void
+@external("env", "ClearBackgroundExpanded")
+declare function ClearBackgroundExpanded(r: i32, g: i32, b: i32, a: i32) :void
+export function ClearBackground(color: Color): void {
+    ClearBackgroundExpanded(color.r, color.g, color.b, color.a)
+}
+
+@external("env", "DrawTextExpanded")
+declare function DrawTextExpanded(text: ArrayBuffer, x: i32, y: i32, fontSize: i32, r: i32, g: i32, b: i32, a: i32) :void
 export function DrawText(text: string, x: i32, y: i32, fontSize: i32, color: Color) :void {
-    _DrawText(String.UTF8.encode(text, true), x, y, fontSize, toColor(color))
+    DrawTextExpanded(String.UTF8.encode(text, true), x, y, fontSize, color.r, color.g, color.b, color.a)
 }

--- a/examples/assemblyscript/src/raylib-wasm.ts
+++ b/examples/assemblyscript/src/raylib-wasm.ts
@@ -111,5 +111,11 @@ export const LOG_ERROR = 5
 export const LOG_FATAL = 6
 export const LOG_NONE = 7
 
+// since it takes a string arg, we convert to a UTF8 null-terminated buffer first
 @external("env", "TraceLog")
-export declare function TraceLog(logLevel: i32, text: string) :void
+declare function raylibTraceLog(logLevel: i32, text: ArrayBuffer) :void
+
+export function TraceLog(logLevel: i32, text: string) :void {
+    raylibTraceLog(logLevel, String.UTF8.encode(text, true))
+}
+

--- a/runtimes/wasi/main.c
+++ b/runtimes/wasi/main.c
@@ -125,8 +125,8 @@ int main(int argc, char *argv[]) {
     }
 
     //TraceLog(LOG_INFO, "ResizeMemory");
-    runtime->memory.maxPages = 1;
-    ResizeMemory(runtime, 1);
+    runtime->memory.maxPages = 1024;
+    ResizeMemory(runtime, 1024);
 
     IM3Module module;
     result = m3_ParseModule(env, &module, fileData, bytesRead);


### PR DESCRIPTION
This gets assemblyscript demo building and working with C runtime.

For `Color` the struct-spread is not really needed (since they all fit in an int32) but it will be needed for other structs, so I just followed it.

It still crashes on mac after about 2 seconds with this:

```
ERROR: malformed Wasm binary -
[1]    17510 bus error  ../../runtimes/wasi/build/raylib-wasm build/cart.wasm
```

I think I got this on null0 at one point, but I can't remember how I fixed it. The errors are really bad, so it's hard to tell what the message means, but I think it's like "something is bad in your exposed function, like it's tying to do something it can't"
